### PR TITLE
♻️refactor: Contrast the command to the function

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -1,8 +1,26 @@
-pub mod check;
-pub mod clean;
-pub mod install;
-pub mod list;
-pub mod remove;
-pub mod search;
-pub mod update;
-pub mod upgrade;
+mod check;
+mod clean;
+mod install;
+mod list;
+mod remove;
+mod search;
+mod update;
+mod upgrade;
+
+// Contrast the command to the function
+// $ lade check
+pub use check::check;
+// $ lade clean
+pub use clean::clean;
+// $ lade install
+pub use install::install;
+// $ lade list
+pub use list::list;
+// $ lade remove
+pub use remove::remove;
+// $ lade search
+pub use search::search_package as search;
+// $ lade update
+pub use update::update;
+// $ lade upgrade
+pub use upgrade::upgrade;

--- a/src/command/upgrade.rs
+++ b/src/command/upgrade.rs
@@ -7,7 +7,7 @@ use crate::{
     consts::{LADE_VERSION, VERSION},
     error, info,
     paths::lade_cache_path,
-    update, upgrade_self,
+    upgrade_self,
 };
 
 #[derive(Serialize, Deserialize)]
@@ -19,7 +19,7 @@ struct Upgrade {
 }
 
 pub fn upgrade() {
-    update::update();
+    super::update();
 
     info!("Downloading upgrade info file");
     download_file(

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,6 @@ mod unzip_file;
 mod upgrade_self;
 mod urls;
 
-use command::*;
-
 #[derive(Parser)]
 struct Cli {
     #[command(subcommand)]
@@ -40,16 +38,16 @@ fn main() {
     let args = Cli::parse();
 
     match args.commands {
-        Subcommands::Install { mut package } => install::install(&mut package).unwrap(),
-        Subcommands::Remove { package } => remove::remove(&package).unwrap_or_else(|e| {
+        Subcommands::Install { mut package } => command::install(&mut package).unwrap(),
+        Subcommands::Remove { package } => command::remove(&package).unwrap_or_else(|e| {
             error!(format!("Error: {}", e), e);
         }),
-        Subcommands::Update => update::update(),
-        Subcommands::List => list::list(),
-        Subcommands::Search { query } => search::search_package(&query),
-        Subcommands::Upgrade => upgrade::upgrade(),
-        Subcommands::Clean => clean::clean(),
-        Subcommands::Check => check::check(),
+        Subcommands::Update => command::update(),
+        Subcommands::List => command::list(),
+        Subcommands::Search { query } => command::search(&query),
+        Subcommands::Upgrade => command::upgrade(),
+        Subcommands::Clean => command::clean(),
+        Subcommands::Check => command::check(),
         Subcommands::Autoclean => todo!("Autocleaning packages"),
     }
 }


### PR DESCRIPTION
Feature:
- Contrast the command to the function

```rs
// Contrast the command to the function
// $ lade check
pub use check::check;
// $ lade clean
pub use clean::clean;
// $ lade install
pub use install::install;
// $ lade list
pub use list::list;
// $ lade remove
pub use remove::remove;
// $ lade search
pub use search::search_package as search;
// $ lade update
pub use update::update;
// $ lade upgrade
pub use upgrade::upgrade;
```
